### PR TITLE
Add @POST annotation to protect against CRSF

### DIFF
--- a/src/main/java/io/jenkins/plugins/buildkite/BuildkiteConfiguration.java
+++ b/src/main/java/io/jenkins/plugins/buildkite/BuildkiteConfiguration.java
@@ -19,6 +19,7 @@ import org.kohsuke.stapler.AncestorInPath;
 import org.kohsuke.stapler.DataBoundSetter;
 import org.kohsuke.stapler.QueryParameter;
 import org.kohsuke.stapler.StaplerRequest2;
+import org.kohsuke.stapler.verb.POST;
 
 import java.net.HttpURLConnection;
 import java.net.URL;
@@ -85,6 +86,7 @@ public class BuildkiteConfiguration extends GlobalConfiguration {
                 .includeCurrentValue(credentialsId);
     }
 
+    @POST
     public FormValidation doTestConnection(
             @QueryParameter("baseUrl") String baseUrl,
             @QueryParameter("credentialsId") String credentialsId


### PR DESCRIPTION
Add `@POST` annotation to protect against CSRF. 

Addresses Jenkins Security Scan failure: https://github.com/jenkins-infra/repository-permissions-updater/issues/4559#issuecomment-3138757484